### PR TITLE
Add google tag and make image removable

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Metadata } from "next";
+import Script from "next/script";
 import { Inter as FontSans, Lato, Nunito } from "next/font/google";
 import { cn } from "@/lib/utils";
 import { VideoDialogProvider } from "@/components/ui/VideoDialogContext";
@@ -36,6 +37,18 @@ export default function RootLayout({
   return (
     <html lang="en" className={cn(fontSans.variable, nunito.variable, lato.variable)}>
       <body className="min-h-screen bg-background font-sans antialiased">
+        <Script
+          src="https://www.googletagmanager.com/gtag/js?id=G-080ZT75Q6V"
+          strategy="afterInteractive"
+        />
+        <Script id="google-analytics" strategy="afterInteractive">
+          {`
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', 'G-080ZT75Q6V');
+          `}
+        </Script>
         <VideoDialogProvider>
           {children}
           <VideoDialog />

--- a/components/blocks/business-card.tsx
+++ b/components/blocks/business-card.tsx
@@ -106,7 +106,7 @@ export const BusinessCard: React.FC<BusinessCardProps> = ({ data }) => {
         </div>
 
         <div className="relative z-10 text-left">
-          <div className="mb-6 flex flex-col-reverse sm:flex-row items-start gap-4">
+          <div className={`mb-6 flex ${photo ? 'flex-col-reverse sm:flex-row' : 'flex-row'} items-start gap-4`}>
             <div className="flex-1 flex flex-col justify-between">
               <div className="flex-[2]">
                 <h1
@@ -157,7 +157,7 @@ export const BusinessCard: React.FC<BusinessCardProps> = ({ data }) => {
               </div>
             </div>
 
-            {photo ? (
+            {photo && (
               <div 
                 className="w-20 h-20 rounded-2xl overflow-hidden ring-1 ring-white/30 shadow-lg cursor-pointer hover:ring-2 hover:ring-white/50 hover:scale-105 transition-all duration-200"
                 style={{
@@ -168,17 +168,6 @@ export const BusinessCard: React.FC<BusinessCardProps> = ({ data }) => {
                 data-tina-field={tinaField(data as any, 'photo')}
               >
                 <Image src={photo} alt={name} width={160} height={160} className="w-20 h-20 object-cover" />
-              </div>
-            ) : (
-              <div 
-                className="w-20 h-20 rounded-2xl bg-gradient-to-br from-cyan-400 to-blue-500 dark:from-cyan-600 dark:to-blue-700 flex items-center justify-center text-white text-2xl font-bold shadow-lg cursor-pointer hover:ring-2 hover:ring-white/50 hover:scale-105 transition-all duration-200"
-                style={{
-                  transform: isAnimating ? `rotate(${360 * spinCount}deg)` : 'rotate(0deg)',
-                  transition: isAnimating ? `transform ${Math.max(0.4, 0.8 / spinCount)}s cubic-bezier(0.25, 0.46, 0.45, 0.94)` : 'transform 0.2s ease-out'
-                }}
-                onClick={handlePhotoClick}
-              >
-                <span data-tina-field={tinaField(data as any, 'initials')}>{initials}</span>
               </div>
             )}
           </div>


### PR DESCRIPTION
Add Google Analytics tracking and make the business card photo element removable.

Google Analytics is integrated using Next.js `Script` component for optimal performance. The business card component now hides the entire photo section when no photo is provided, instead of displaying initials.

---
<a href="https://cursor.com/background-agent?bcId=bc-6df79d5b-046f-43bf-b8c1-d72108b14bf2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6df79d5b-046f-43bf-b8c1-d72108b14bf2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

